### PR TITLE
Replace device index literal with variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -199,7 +199,7 @@ func main() {
         sdrIndex = indexreturn
     }
 
-    dev, err := rtlsdr.Open(0)
+    dev, err := rtlsdr.Open(sdrIndex)
     if err != nil {
         log.Fatal(err)
     }


### PR DESCRIPTION
Although the -d parameter is accepted, it doesn't seem to have any effect. Guessing that the issue is the "Open" call is hard coded to 0.