### PR TITLE
Use selected RTL-SDR device index

### DIFF
--- a/main.go
+++ b/main.go
@@ -199,7 +199,8 @@ func main() {
         sdrIndex = indexreturn
     }
 
-    dev, err := rtlsdr.Open(0)
+    log.Printf("Opening RTL-SDR device index %d from deviceString=%s", sdrIndex, *deviceString)
+    dev, err := rtlsdr.Open(sdrIndex)
     if err != nil {
         log.Fatal(err)
     }


### PR DESCRIPTION
The -d flag is parsed into sdrIndex, supporting either a device serial number or device index, but the program still opened RTL-SDR device 0 unconditionally.

This caused the wrong RTL-SDR dongle to be claimed on systems with multiple RTL-SDR devices attached.

This change uses the parsed sdrIndex when opening the device.